### PR TITLE
Phase 3: Document generator with sequential context accumulation

### DIFF
--- a/src/agent/generate/generator.test.ts
+++ b/src/agent/generate/generator.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { generateDocuments } from "./generator.js";
+import type { GenerateOptions } from "./generator.js";
+import type { ModelClient } from "../model/client.js";
+import type { InterviewState } from "../interview/state.js";
+import type { CompletionRequest, CompletionResponse } from "../model/types.js";
+import type { DocumentType } from "./types.js";
+import { useTempDir } from "../../test-utils.js";
+
+const makeTempDir = useTempDir("generator-test");
+
+const makeState = (): InterviewState => ({
+  sessionId: "test-session",
+  turns: [
+    { role: "assistant", content: "What are you building?" },
+    { role: "user", content: "A project management CLI." },
+  ],
+  complete: true,
+  turnCount: 1,
+});
+
+const makeResponse = (content: string): CompletionResponse => ({
+  content,
+  usage: { inputTokens: 100, outputTokens: 50 },
+  durationMs: 500,
+});
+
+const makeMockClient = (responses: Record<string, string>): ModelClient => ({
+  complete: vi.fn(async (request: CompletionRequest) => {
+    const docType = request.messages[0].content
+      .match(/Generate the (\w+) document/)?.[1]
+      ?.toLowerCase();
+    return makeResponse(responses[docType ?? ""] ?? "# Default");
+  }),
+  completeStream: vi.fn(),
+});
+
+describe("generateDocuments", () => {
+  it("generates all four documents in order", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# Vision\n\nThe vision.",
+      prd: "# PRD\n\nThe requirements.",
+      architecture: "# Architecture\n\nThe design.",
+      milestones: "# Milestones\n\nThe roadmap.",
+    });
+
+    const docs = await generateDocuments({
+      client,
+      state: makeState(),
+      rootDir,
+    });
+
+    expect(docs.vision).toContain("The vision.");
+    expect(docs.prd).toContain("The requirements.");
+    expect(docs.architecture).toContain("The design.");
+    expect(docs.milestones).toContain("The roadmap.");
+  });
+
+  it("writes documents to the filesystem", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# Vision",
+      prd: "# PRD",
+      architecture: "# Architecture",
+      milestones: "# Milestones",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    expect(readFileSync(join(rootDir, "docs/VISION.md"), "utf-8")).toContain(
+      "# Vision",
+    );
+    expect(readFileSync(join(rootDir, "docs/PRD.md"), "utf-8")).toContain(
+      "# PRD",
+    );
+    expect(
+      readFileSync(join(rootDir, "docs/ARCHITECTURE.md"), "utf-8"),
+    ).toContain("# Architecture");
+    expect(
+      readFileSync(join(rootDir, "docs/MILESTONES.md"), "utf-8"),
+    ).toContain("# Milestones");
+  });
+
+  it("appends trailing newline to written files", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# Vision",
+      prd: "# PRD",
+      architecture: "# Arch",
+      milestones: "# Miles",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    const content = readFileSync(join(rootDir, "docs/VISION.md"), "utf-8");
+    expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("calls model with system prompt containing interview context", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# V",
+      prd: "# P",
+      architecture: "# A",
+      milestones: "# M",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    const calls = (client.complete as ReturnType<typeof vi.fn>).mock.calls;
+    const firstCall = calls[0][0] as CompletionRequest;
+    expect(firstCall.system).toContain("VISION.md");
+    expect(firstCall.system).toContain("project management CLI");
+  });
+
+  it("passes previously generated docs as context to later generations", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# Vision\n\nCore vision content.",
+      prd: "# PRD",
+      architecture: "# Architecture",
+      milestones: "# Milestones",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    const calls = (client.complete as ReturnType<typeof vi.fn>).mock.calls;
+
+    // First call (vision) should NOT have previous docs
+    const visionPrompt = (calls[0][0] as CompletionRequest).system!;
+    expect(visionPrompt).not.toContain("Previously generated:");
+
+    // Second call (prd) should have vision
+    const prdPrompt = (calls[1][0] as CompletionRequest).system!;
+    expect(prdPrompt).toContain("Previously generated: VISION.md");
+    expect(prdPrompt).toContain("Core vision content.");
+
+    // Fourth call (milestones) should have all three
+    const milestonesPrompt = (calls[3][0] as CompletionRequest).system!;
+    expect(milestonesPrompt).toContain("Previously generated: VISION.md");
+    expect(milestonesPrompt).toContain("Previously generated: PRD.md");
+    expect(milestonesPrompt).toContain("Previously generated: ARCHITECTURE.md");
+  });
+
+  it("calls onDocGenerated callback for each document", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# V",
+      prd: "# P",
+      architecture: "# A",
+      milestones: "# M",
+    });
+    const generated: Array<[DocumentType, string]> = [];
+
+    await generateDocuments({
+      client,
+      state: makeState(),
+      rootDir,
+      onDocGenerated: (docType, content) => generated.push([docType, content]),
+    });
+
+    expect(generated).toHaveLength(4);
+    expect(generated[0][0]).toBe("vision");
+    expect(generated[1][0]).toBe("prd");
+    expect(generated[2][0]).toBe("architecture");
+    expect(generated[3][0]).toBe("milestones");
+  });
+
+  it("creates docs directory if it does not exist", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# V",
+      prd: "# P",
+      architecture: "# A",
+      milestones: "# M",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    // Verify files exist (docs/ was created)
+    expect(readFileSync(join(rootDir, "docs/VISION.md"), "utf-8")).toBeTruthy();
+  });
+
+  it("makes exactly 4 model calls", async () => {
+    const rootDir = makeTempDir();
+    const client = makeMockClient({
+      vision: "# V",
+      prd: "# P",
+      architecture: "# A",
+      milestones: "# M",
+    });
+
+    await generateDocuments({ client, state: makeState(), rootDir });
+
+    expect(client.complete).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/agent/generate/generator.ts
+++ b/src/agent/generate/generator.ts
@@ -1,0 +1,50 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, dirname, resolve } from "node:path";
+import type { ModelClient } from "../model/client.js";
+import type { InterviewState } from "../interview/state.js";
+import type { DocumentType, GeneratedDocs } from "./types.js";
+import { DOCUMENT_ORDER, DOCUMENT_PATHS } from "./types.js";
+import { buildGenerationPrompt } from "./prompts.js";
+
+export interface GenerateOptions {
+  readonly client: ModelClient;
+  readonly state: InterviewState;
+  readonly rootDir: string;
+  readonly onDocGenerated?: (docType: DocumentType, content: string) => void;
+}
+
+export const generateDocuments = async (
+  options: GenerateOptions,
+): Promise<GeneratedDocs> => {
+  const { client, state, rootDir, onDocGenerated } = options;
+  const resolvedRoot = resolve(rootDir);
+  const docs: Record<string, string> = {};
+
+  for (const docType of DOCUMENT_ORDER) {
+    const systemPrompt = buildGenerationPrompt(
+      docType,
+      state,
+      docs as GeneratedDocs,
+    );
+
+    const response = await client.complete({
+      system: systemPrompt,
+      messages: [
+        {
+          role: "user",
+          content: `Generate the ${docType.toUpperCase()} document now.`,
+        },
+      ],
+    });
+
+    docs[docType] = response.content;
+
+    const filePath = join(resolvedRoot, DOCUMENT_PATHS[docType]);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, response.content + "\n");
+
+    onDocGenerated?.(docType, response.content);
+  }
+
+  return docs as GeneratedDocs;
+};

--- a/src/agent/generate/prompts.test.ts
+++ b/src/agent/generate/prompts.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { buildGenerationPrompt } from "./prompts.js";
+import type { InterviewState } from "../interview/state.js";
+import type { GeneratedDocs } from "./types.js";
+
+const makeState = (
+  turns: Array<{ role: "user" | "assistant"; content: string }> = [],
+): InterviewState => ({
+  sessionId: "test-session",
+  turns,
+  complete: true,
+  turnCount: turns.filter((t) => t.role === "user").length,
+});
+
+describe("buildGenerationPrompt", () => {
+  it("includes document-specific instructions for vision", () => {
+    const prompt = buildGenerationPrompt("vision", makeState(), {});
+    expect(prompt).toContain("VISION.md");
+    expect(prompt).toContain("Principles");
+  });
+
+  it("includes document-specific instructions for prd", () => {
+    const prompt = buildGenerationPrompt("prd", makeState(), {});
+    expect(prompt).toContain("PRD.md");
+    expect(prompt).toContain("User Journeys");
+  });
+
+  it("includes document-specific instructions for architecture", () => {
+    const prompt = buildGenerationPrompt("architecture", makeState(), {});
+    expect(prompt).toContain("ARCHITECTURE.md");
+    expect(prompt).toContain("Components");
+  });
+
+  it("includes document-specific instructions for milestones", () => {
+    const prompt = buildGenerationPrompt("milestones", makeState(), {});
+    expect(prompt).toContain("MILESTONES.md");
+    expect(prompt).toContain("Acceptance Criteria");
+  });
+
+  it("includes conversation history from interview", () => {
+    const state = makeState([
+      { role: "assistant", content: "What are you building?" },
+      { role: "user", content: "A CLI tool for project management." },
+    ]);
+
+    const prompt = buildGenerationPrompt("vision", state, {});
+    expect(prompt).toContain("CLI tool for project management");
+    expect(prompt).toContain("Developer:");
+    expect(prompt).toContain("Interviewer:");
+  });
+
+  it("includes previously generated documents", () => {
+    const previousDocs: GeneratedDocs = {
+      vision: "# Vision\n\nThis is the vision.",
+    };
+
+    const prompt = buildGenerationPrompt("prd", makeState(), previousDocs);
+    expect(prompt).toContain("Previously generated: VISION.md");
+    expect(prompt).toContain("This is the vision.");
+  });
+
+  it("includes multiple previous documents for later generations", () => {
+    const previousDocs: GeneratedDocs = {
+      vision: "# Vision content",
+      prd: "# PRD content",
+      architecture: "# Architecture content",
+    };
+
+    const prompt = buildGenerationPrompt(
+      "milestones",
+      makeState(),
+      previousDocs,
+    );
+    expect(prompt).toContain("Previously generated: VISION.md");
+    expect(prompt).toContain("Previously generated: PRD.md");
+    expect(prompt).toContain("Previously generated: ARCHITECTURE.md");
+  });
+
+  it("omits previous docs section when no docs provided", () => {
+    const prompt = buildGenerationPrompt("vision", makeState(), {});
+    expect(prompt).not.toContain("Previously generated:");
+  });
+
+  it("instructs model to return only markdown", () => {
+    const prompt = buildGenerationPrompt("vision", makeState(), {});
+    expect(prompt).toContain("ONLY the markdown document");
+  });
+});

--- a/src/agent/generate/prompts.ts
+++ b/src/agent/generate/prompts.ts
@@ -1,0 +1,120 @@
+import type { InterviewState } from "../interview/state.js";
+import type { DocumentType, GeneratedDocs } from "./types.js";
+
+const formatConversation = (state: InterviewState): string =>
+  state.turns
+    .map(
+      (t) => `${t.role === "user" ? "Developer" : "Interviewer"}: ${t.content}`,
+    )
+    .join("\n\n");
+
+const formatPreviousDocs = (docs: GeneratedDocs): string => {
+  const sections: string[] = [];
+  if (docs.vision)
+    sections.push(`## Previously generated: VISION.md\n\n${docs.vision}`);
+  if (docs.prd) sections.push(`## Previously generated: PRD.md\n\n${docs.prd}`);
+  if (docs.architecture)
+    sections.push(
+      `## Previously generated: ARCHITECTURE.md\n\n${docs.architecture}`,
+    );
+  if (docs.milestones)
+    sections.push(
+      `## Previously generated: MILESTONES.md\n\n${docs.milestones}`,
+    );
+  return sections.length > 0 ? sections.join("\n\n---\n\n") : "";
+};
+
+const DOCUMENT_PROMPTS: Readonly<Record<DocumentType, string>> = {
+  vision: `You are generating a VISION.md document for a software project.
+
+## Purpose
+VISION.md captures the project's foundational "why" — its purpose, the problem it solves, and the principles that guide its development. It is the document that new contributors read first.
+
+## Expected structure
+1. **Title and tagline** — project name and one-sentence description
+2. **The Problem** — what pain point or gap this project addresses
+3. **The Vision** — what the world looks like when this project succeeds
+4. **Principles** — 4-6 guiding principles that shape design decisions
+5. **What This Is / What This Isn't** — clear scope boundaries
+
+## Instructions
+- Write substantive content, not placeholders or skeletons
+- Use clear, direct language — no marketing fluff
+- Ground everything in the interview conversation
+- Return ONLY the markdown document, no preamble or explanation`,
+
+  prd: `You are generating a PRD.md (Product Requirements Document) for a software project.
+
+## Purpose
+PRD.md defines what the project does from a user's perspective — the requirements, user journeys, and success criteria.
+
+## Expected structure
+1. **Overview** — one-paragraph summary
+2. **User Journeys** — 2-4 key workflows described step by step
+3. **Requirements** — grouped by feature area, with clear acceptance criteria
+4. **Non-functional Requirements** — performance, security, reliability constraints
+5. **Success Criteria** — measurable outcomes that define "done"
+
+## Instructions
+- Write substantive content, not placeholders or skeletons
+- Requirements should be specific and testable
+- Reference the VISION.md for alignment on purpose and principles
+- Return ONLY the markdown document, no preamble or explanation`,
+
+  architecture: `You are generating an ARCHITECTURE.md document for a software project.
+
+## Purpose
+ARCHITECTURE.md describes how the system is built — its components, their relationships, data flow, and the conventions that keep the codebase coherent.
+
+## Expected structure
+1. **System Overview** — high-level architecture diagram description
+2. **Components** — each major component with its responsibility
+3. **Data Flow** — how data moves through the system
+4. **Working Conventions** — code organization, naming, testing patterns
+5. **Key Decisions** — important architectural choices and their rationale
+
+## Instructions
+- Write substantive content, not placeholders or skeletons
+- Be specific about technology choices, patterns, and conventions
+- Reference VISION.md for principles and PRD.md for requirements
+- Return ONLY the markdown document, no preamble or explanation`,
+
+  milestones: `You are generating a MILESTONES.md document for a software project.
+
+## Purpose
+MILESTONES.md defines the development roadmap — what gets built in what order, with clear acceptance criteria for each milestone.
+
+## Expected structure
+1. **Current Milestone** — marked with status, goal, acceptance criteria, build sequence
+2. **Future Milestones** — 2-4 subsequent milestones with goals and rough scope
+3. Each milestone should have:
+   - **Goal** — one sentence on what this milestone achieves
+   - **Acceptance Criteria** — numbered, testable criteria
+   - **Build Sequence** — ordered phases within the milestone
+
+## Instructions
+- Write substantive content, not placeholders or skeletons
+- Make the first milestone achievable and well-scoped
+- Acceptance criteria should be specific and testable
+- Reference all previously generated documents for context
+- Return ONLY the markdown document, no preamble or explanation`,
+};
+
+export const buildGenerationPrompt = (
+  docType: DocumentType,
+  state: InterviewState,
+  previousDocs: GeneratedDocs,
+): string => {
+  const parts = [DOCUMENT_PROMPTS[docType]];
+
+  parts.push(
+    `\n\n## Project context (from developer interview)\n\n${formatConversation(state)}`,
+  );
+
+  const prevDocsSection = formatPreviousDocs(previousDocs);
+  if (prevDocsSection) {
+    parts.push(`\n\n---\n\n${prevDocsSection}`);
+  }
+
+  return parts.join("");
+};

--- a/src/agent/generate/types.ts
+++ b/src/agent/generate/types.ts
@@ -1,0 +1,22 @@
+export type DocumentType = "vision" | "prd" | "architecture" | "milestones";
+
+export interface GeneratedDocs {
+  readonly vision?: string;
+  readonly prd?: string;
+  readonly architecture?: string;
+  readonly milestones?: string;
+}
+
+export const DOCUMENT_ORDER: readonly DocumentType[] = [
+  "vision",
+  "prd",
+  "architecture",
+  "milestones",
+];
+
+export const DOCUMENT_PATHS: Readonly<Record<DocumentType, string>> = {
+  vision: "docs/VISION.md",
+  prd: "docs/PRD.md",
+  architecture: "docs/ARCHITECTURE.md",
+  milestones: "docs/MILESTONES.md",
+};


### PR DESCRIPTION
## Summary

- Implements the document generation pipeline for `telesis init` (Phase 3 of v0.2.0 build sequence)
- **Types** (`types.ts`): `DocumentType` union, `GeneratedDocs` interface, `DOCUMENT_ORDER` and `DOCUMENT_PATHS` constants
- **Prompts** (`prompts.ts`): Per-document system prompts for VISION.md, PRD.md, ARCHITECTURE.md, MILESTONES.md — each includes interview conversation context and sequentially accumulated previous documents
- **Generator** (`generator.ts`): Calls `ModelClient.complete()` for each document in order, writes to `docs/`, supports `onDocGenerated` callback for progress reporting
- **17 new tests** across 2 test files (171 total)

### Key design decisions
- Sequential generation with context accumulation: each document sees all prior docs (VISION informs PRD, both inform ARCHITECTURE, all three inform MILESTONES)
- Uses `ModelClient.complete()` (not streaming) since generated docs aren't displayed incrementally
- `onDocGenerated` callback enables the CLI layer to report progress without the generator knowing about terminal I/O
- `docs/` directory created automatically if missing

### References
- TDD-001 (Init Agent), Phase 3: Document Generator
- Depends on PR #8 (Model Client) and PR #10 (Interview Engine) — both merged

## Test plan
- [x] 9 prompt tests: document-specific content, conversation context, previous doc inclusion, markdown-only instruction
- [x] 8 generator tests: all docs generated in order, filesystem writes, trailing newline, system prompt content, context accumulation across calls, callback invocation, directory creation, exactly 4 model calls
- [x] All 171 tests pass, lint clean
- [x] Local bop review: no findings