### PR TITLE
Phase 3: Improve generation prompts for principle quality and tech specificity

### DIFF
--- a/src/agent/generate/prompts.test.ts
+++ b/src/agent/generate/prompts.test.ts
@@ -143,4 +143,28 @@ describe("buildGenerationPrompt", () => {
     const contextIndex = prompt.indexOf("Project context");
     expect(topicsIndex).toBeLessThan(contextIndex);
   });
+
+  describe("vision prompt — principle quality (#15)", () => {
+    it("instructs against restating features as principles", () => {
+      const prompt = buildGenerationPrompt("vision", makeState(), {});
+      expect(prompt).toContain("Do not restate features as principles");
+    });
+
+    it("instructs principles to guide ambiguous decisions", () => {
+      const prompt = buildGenerationPrompt("vision", makeState(), {});
+      expect(prompt).toContain("resolve ambiguous design decisions");
+    });
+  });
+
+  describe("architecture prompt — decided vs suggested (#17)", () => {
+    it("instructs to distinguish decided from suggested technologies", () => {
+      const prompt = buildGenerationPrompt("architecture", makeState(), {});
+      expect(prompt).toContain("explicitly chosen");
+    });
+
+    it("instructs to frame undiscussed choices as options", () => {
+      const prompt = buildGenerationPrompt("architecture", makeState(), {});
+      expect(prompt).toContain("options to evaluate");
+    });
+  });
 });

--- a/src/agent/generate/prompts.ts
+++ b/src/agent/generate/prompts.ts
@@ -45,6 +45,8 @@ VISION.md captures the project's foundational "why" — its purpose, the problem
 - Ground everything in the interview conversation
 - Ensure every topic from the interview checklist below appears somewhere in the document
 - Principles must be specific to THIS project, derived from the interview — not generic advice
+- Do not restate features as principles. A principle should resolve ambiguous design decisions, not describe what the project does. For example, "When in doubt, prioritize simplicity over configurability" is a useful principle; "Simple Configuration" is just a feature label.
+- Each principle should help a developer choose between two reasonable options when the answer isn't obvious
 - Return ONLY the markdown document, no preamble or explanation`,
 
   prd: `You are generating a PRD.md (Product Requirements Document) for a software project.
@@ -85,6 +87,7 @@ ARCHITECTURE.md describes how the system is built — its components, their rela
 - Be specific about technology choices, patterns, and conventions
 - Include developer preferences (coding style, paradigm preferences, etc.) in Working Conventions
 - ONLY describe components and technology choices that were explicitly discussed in the interview — do NOT fabricate implementation details
+- Distinguish between technologies the developer has explicitly chosen and areas where the choice is still open. Mark explicitly chosen technologies as decisions; frame undiscussed or loosely-mentioned alternatives as options to evaluate
 - Reference VISION.md for principles and PRD.md for requirements
 - Return ONLY the markdown document, no preamble or explanation`,
 


### PR DESCRIPTION
## Summary

- **Vision prompt (#15):** Added instructions against restating features as principles. Principles should resolve ambiguous design decisions, not label features. Includes a concrete good-vs-bad example.
- **Architecture prompt (#17):** Added instruction to distinguish explicitly chosen technologies from loosely mentioned alternatives, framing undiscussed choices as "options to evaluate" rather than decisions.
- **PRD out-of-scope (#19):** Already resolved in Phase 2 — no additional changes needed.

Closes #15
Closes #17
Closes #19

## Test plan

- [x] 4 new tests verify prompt content for principle-quality and decided-vs-suggested instructions
- [x] All 282 tests pass
- [x] Local bop review: 0 findings
- [ ] CI bop review passes