### PR TITLE
Phase 4: Fix config extraction to record languages, not frameworks

### DIFF
--- a/src/agent/init/config-extract.test.ts
+++ b/src/agent/init/config-extract.test.ts
@@ -178,4 +178,16 @@ describe("extractConfig", () => {
 
     expect(config.project.name).toBe("myproject");
   });
+
+  it("prompt instructs to extract languages not frameworks", async () => {
+    const client = makeClient(
+      JSON.stringify({ name: "test", owner: "", language: "TypeScript" }),
+    );
+
+    await extractConfig(client, makeState());
+
+    const calls = (client.complete as ReturnType<typeof vi.fn>).mock.calls;
+    const request = calls[0][0] as CompletionRequest;
+    expect(request.system).toContain("not frameworks");
+  });
 });

--- a/src/agent/init/config-extract.ts
+++ b/src/agent/init/config-extract.ts
@@ -10,7 +10,7 @@ From the conversation below, extract these fields:
 
 - **name**: The project name (required). If the developer did not state an explicit name, infer a short, lowercase, hyphenated name from what the project does (e.g., "tic-tac-toe", "expense-tracker").
 - **owner**: The organization or individual who owns the project
-- **language**: The primary programming language(s)
+- **language**: The primary programming language(s), not frameworks. If the developer mentions a framework (e.g., React, Next.js, Express, Rails), record the underlying language (TypeScript, JavaScript, Ruby), not the framework name
 - **repo**: The repository URL (if mentioned)
 
 ## Output format


### PR DESCRIPTION
## Summary

- Updated the config extraction prompt to instruct the model to normalize framework mentions (React, Express, Rails) to their underlying programming language (TypeScript, JavaScript, Ruby)
- Prevents misleading `language: React` in config.yml and downstream documents (CLAUDE.md, status output)

Closes #16

## Test plan

- [x] New test verifies prompt contains framework-vs-language instruction
- [x] All 283 tests pass
- [x] Local bop review: 0 findings
- [ ] CI bop review passes